### PR TITLE
Update csharp-6.md

### DIFF
--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -256,9 +256,10 @@ El tipo <xref:System.FormattableString> contiene la cadena de formato y los resu
 
 ```csharp
 FormattableString str = $"Average grade is {s.Grades.Average()}";
-var gradeStr = string.Format(null, 
-    System.Globalization.CultureInfo.CreateSpecificCulture("de-de"),
-    str.GetFormat(), str.GetArguments());
+var gradeStr = string.Format(System.Globalization.CultureInfo.CreateSpecificCulture("de-de"),
+    str.Format, str.GetArguments());
+
+var gradeStr2 = str.ToString(System.Globalization.CultureInfo.CreateSpecificCulture("de-de"));
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Example code for cultural dependent formatting wrong, and also FormattableString has a toString overload specifically for this purpose.