### PR TITLE
Update new-constraint.md

### DIFF
--- a/docs/csharp/language-reference/keywords/new-constraint.md
+++ b/docs/csharp/language-reference/keywords/new-constraint.md
@@ -18,7 +18,7 @@ ms.contentlocale: es-ES
 ms.lasthandoff: 11/21/2017
 ---
 # <a name="new-constraint-c-reference"></a>Restricción new (Referencia de C#)
-La restricción `new` especifica que ningún tipo de argumento en una declaración de clase genérica debe tener un constructor sin parámetros público. Para usar la restricción new, el tipo no puede ser abstracto.  
+La restricción `new` especifica que cualquier tipo de argumento en una declaración de clase genérica debe tener un constructor sin parámetros público. Para usar la restricción new, el tipo no puede ser abstracto.  
   
 ## <a name="example"></a>Ejemplo  
  Aplique la restricción `new` a un tipo de parámetro cuando la clase genérica cree otras instancias del tipo, tal y como se muestra en el ejemplo siguiente:  


### PR DESCRIPTION
In the original document we can read "The new constraint specifies that any type argument in a generic class ". "Any" is translated as "ningún", but it should be "cualquier". The sentence as is now translated has the opposite meaning to what it should have.