### PR TITLE
Corrección de traducción confusa

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -61,7 +61,7 @@ Esta documentación es completamente de [código abierto](https://github.com/dot
 
 - [Página principal de .NET Core](https://github.com/dotnet/core)
 - [Bibliotecas de .NET](https://github.com/dotnet/corefx)
-- [Tiempo de ejecución de .NET Core](https://github.com/dotnet/coreclr)
+- [Entorno en tiempo de ejecución (runtime enviroment) de .NET Core](https://github.com/dotnet/coreclr)
 - [Plataforma del compilador de Roslyn (C# y Visual Basic) y herramientas de IDE](https://github.com/dotnet/roslyn)
 - [Compilador de F# y herramientas de IDE](https://github.com/microsoft/visualfsharp)
 


### PR DESCRIPTION
Si bien 'runtime' se traduce literalmente a 'tiempo de ejecución', la traducción no tiene mucho sentido en este contexto. La cambié para que sea mas adecuada y agregué el nombre en inglés para despejar dudas.