### PR TITLE
Bad order in words

### DIFF
--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -17,7 +17,7 @@ ms.locfileid: "68363124"
 ---
 # <a name="yield-c-reference"></a>yield (Referencia de C#)
 
-Cuando se usa la `yield`palabra [clave contextual](index.md#contextual-keywords) en una instrucción, se indica que el método, el operador o el descriptor de acceso `get` en el que aparece es un iterador. Al usar `yield` para definir un iterador ya no es necesaria una clase adicional explícita (la clase que retiene el estado para una enumeración, consulte <xref:System.Collections.Generic.IEnumerator%601> para ver un ejemplo) al implementar los patrones <xref:System.Collections.IEnumerable> y <xref:System.Collections.IEnumerator> para un tipo de colección personalizado.
+Cuando se usa la [palabra clave contextual](index.md#contextual-keywords) `yield` en una instrucción, se indica que el método, el operador o el descriptor de acceso `get` en el que aparece es un iterador. Al usar `yield` para definir un iterador ya no es necesaria una clase adicional explícita (la clase que retiene el estado para una enumeración, consulte <xref:System.Collections.Generic.IEnumerator%601> para ver un ejemplo) al implementar los patrones <xref:System.Collections.IEnumerable> y <xref:System.Collections.IEnumerator> para un tipo de colección personalizado.
 
 En el ejemplo siguiente se muestran las dos formas de la instrucción `yield`.
 


### PR DESCRIPTION
The original phrase at the beginning:

>Cuando se usa la `yield` palabra clave contextual en una instrucción

is not correct in Spanish. Looks like the result of an automatic translation.

Apart from that since "palabra" is the directo object of the adjectives "clave contextual", it is a whole and should be inside the link too:

>Cuando se usa la [palabra clave contextual](index.md#contextual-keywords) `yield` en una instrucción

It should read

Información útil para hacer una sugerencia:
1. Vaya a [Quick Start Localization Style Guides(Guías de estilo de localización de inicio rápido)](https://docs.Microsoft.com/Globalization/Localization/styleguides) para comprobar las **diez reglas más importantes** de la guía de estilo de Microsoft.
2. Vaya a [Portal lingüístico de Microsoft](https://www.Microsoft.com/Language) para comprobar la **traducción normalizada de un término** en todos los productos de Microsoft.
